### PR TITLE
Make /datasets a proper route that is root default

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import { AuthProvider } from "./providers/AuthProvider";
 import { TasksProvider } from "./providers/TasksProvider";
 import { createEmotionCache } from './utils/create-emotion-cache';
 import { theme } from './theme';
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, Navigate } from "react-router-dom";
 import LoginPage from "./pages/login";
 
 
@@ -41,7 +41,7 @@ export default function App(props) {
                   <SnackbarProvider maxSnack={3}>
                     <CssBaseline/>
                     <Routes>
-                      <Route path="/" element={DatasetsPage.getLayout(<DatasetsPage/>)}/>
+                      <Route path="/" element={<Navigate replace to="/datasets"/>}/>
                       <Route path="/datasets" element={DatasetsPage.getLayout(<DatasetsPage/>)}/>
                       <Route path="/reports" element={ReportsPage.getLayout(<ReportsPage/>)}/>
                       <Route path="/report/:rid" element={NotebookPage.getLayout(<NotebookPage/>)}/>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -16,7 +16,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 
 const items = [
   {
-    href: '/', icon: (<WarehouseIcon fontSize="small"/>), title: 'Datasets'
+    href: '/datasets', icon: (<WarehouseIcon fontSize="small"/>), title: 'Datasets'
   },
   {
     href: '/reports', icon: (<ArticleIcon fontSize="small"/>), title: 'Reports'
@@ -30,10 +30,6 @@ const items = [
   {
     href: '/triplydb', icon: (<StorageIcon fontSize="small"/>), title: 'TriplyDB'
   },
-  // {
-  //   href: '/datasets', icon: (<UsersIcon fontSize="small"/>), title: 'Datasets'
-  // },
-
 ];
 
 const bottomItems = [


### PR DESCRIPTION
While adding a new page to the sidebar, I noticed that the root route does render the contents behind `/datasets`, but not via this route.
Although `/datasets` is registered as a route in `App.tsx`, the root route is used for this page instead.

So I fixed it by making `/datasets` a proper route, after login it goes to `/` which redirects to `/datasets`, and you can easily change it in one place if you want a different default page after login. So the behavior is the same, and now it is its own route that decides how to render itself. And of course it highlights `Datasets` in the sidebar, as it is the current route.
