### PR TITLE
Provide templates for url imports from common sources

### DIFF
--- a/frontend/src/containers/datasets/DatasetCreateForm.tsx
+++ b/frontend/src/containers/datasets/DatasetCreateForm.tsx
@@ -81,6 +81,11 @@ export const DatasetCreateForm = (props: {
         }
       }
 
+      if (values.name === '') {
+        sendNotification({ variant: "error", message: "Enter a name for the database" });
+        return;
+      }
+
       setLoading(true);
       try {
         let result;

--- a/frontend/src/containers/datasets/DatasetCreateForm.tsx
+++ b/frontend/src/containers/datasets/DatasetCreateForm.tsx
@@ -75,8 +75,12 @@ export const DatasetCreateForm = (props: {
             sendNotification({ variant: "error", message: "Select the type of DBPedia item to query" });
             return;
           }
-          if (!values.source.startsWith('http')) {
+          if (values.source !== '' && !values.source.startsWith('http')) {
             values.source = "https://dbpedia.org/" + prefix + values.source + ".rdf";
+          }
+          else if (!values.source.startsWith('http')) {
+            sendNotification({ variant: "error", message: "Enter the name of the item to query or full url" });
+            return;
           }
         }
       }

--- a/frontend/src/containers/datasets/DatasetCreateForm.tsx
+++ b/frontend/src/containers/datasets/DatasetCreateForm.tsx
@@ -22,6 +22,7 @@ export const DatasetCreateForm = (props: {
   onClose: (created: boolean) => void;
 }) => {
   const [ mode, setMode ] = useState('existing');
+  const [ modeUrl, setModeUrl ] = useState('raw');
   const [ loading, setLoading ] = useState(false);
   const { sendNotification } = useNotification();
   const {
@@ -148,15 +149,24 @@ export const DatasetCreateForm = (props: {
             <TabPanel value="urls">
               <Grid container spacing={3}>
                 <Grid item xs={12}>
-                  <TextField
-                    label="URL(s) to dataset"
-                    placeholder="Urls separated by newline"
-                    variant="outlined"
-                    multiline
-                    rows={3}
-                    fullWidth
-                    {...fieldProps(formik, 'source')}
-                  />
+                  <TabContext value={modeUrl}>
+                    <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                      <TabList onChange={(e, v) => setModeUrl(v)} centered>
+                        <Tab label="Custom URL" value="raw"/>
+                      </TabList>
+                    </Box>
+                    <TabPanel value="raw">
+                      <TextField
+                        label="URL(s) to dataset"
+                        placeholder="Urls separated by newline"
+                        variant="outlined"
+                        multiline
+                        rows={3}
+                        fullWidth
+                        {...fieldProps(formik, 'source')}
+                      />
+                    </TabPanel>
+                  </TabContext>
                 </Grid>
               </Grid>
             </TabPanel>

--- a/frontend/src/containers/datasets/DatasetCreateForm.tsx
+++ b/frontend/src/containers/datasets/DatasetCreateForm.tsx
@@ -57,8 +57,12 @@ export const DatasetCreateForm = (props: {
             sendNotification({ variant: "error", message: "Select the type of WikiData item to query" });
             return;
           }
-          if (!values.source.startsWith('http')) {
+          if (/^\d+$/.test(values.source)) {
             values.source = "https://www.wikidata.org/wiki/Special:EntityData?id=" + prefix + values.source + "&format=rdf";
+          }
+          else if (!values.source.startsWith('http')) {
+            sendNotification({ variant: "error", message: "Enter only the identifier number or full url" });
+            return;
           }
         }
         if (modeUrl === 'dbpedia') {

--- a/frontend/src/containers/datasets/DatasetCreateForm.tsx
+++ b/frontend/src/containers/datasets/DatasetCreateForm.tsx
@@ -61,6 +61,20 @@ export const DatasetCreateForm = (props: {
             values.source = "https://www.wikidata.org/wiki/Special:EntityData?id=" + prefix + values.source + "&format=rdf";
           }
         }
+        if (modeUrl === 'dbpedia') {
+          let prefix = '';
+          if (modeUrlItem === 'entity') {
+            prefix = 'data/';
+          } else if (modeUrlItem === 'class') {
+            prefix = 'data3/';
+          } else {
+            sendNotification({ variant: "error", message: "Select the type of DBPedia item to query" });
+            return;
+          }
+          if (!values.source.startsWith('http')) {
+            values.source = "https://dbpedia.org/" + prefix + values.source + ".rdf";
+          }
+        }
       }
 
       setLoading(true);
@@ -171,6 +185,7 @@ export const DatasetCreateForm = (props: {
                       <TabList onChange={(e, v) => setModeUrl(v)} centered>
                         <Tab label="Custom URL" value="raw"/>
                         <Tab label="WikiData" value="wikidata"/>
+                        <Tab label="DBPedia" value="dbpedia"/>
                       </TabList>
                     </Box>
                     <TabPanel value="raw">
@@ -202,6 +217,31 @@ export const DatasetCreateForm = (props: {
                       <TextField
                         label={modeUrlItem}
                         placeholder="write the identifier number here"
+                        variant="outlined"
+                        multiline
+                        rows={3}
+                        fullWidth
+                        {...fieldProps(formik, 'source')}
+                      />
+                    </TabPanel>
+                    <TabPanel value="dbpedia">
+                      <Box display="flex" alignItems="center" justifyContent="space-between" marginBottom="1em">
+                        Select the type of item to import:
+                        <Select
+                          defaultValue=""
+                          placeholder="Select an option"
+                          value={modeUrlItem}
+                          onChange={(event, newValue: ReactElement) => setModeUrlItem(newValue.props.value)}>
+                          {[['entity', 'entity (owl:Thing)'], ['class', 'class (owl:Class)']].map((option, index) => (
+                            <MenuItem key={index} value={option[0]}>
+                              {option[1]}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </Box>
+                      <TextField
+                        label={modeUrlItem}
+                        placeholder="write the identifier name here"
                         variant="outlined"
                         multiline
                         rows={3}


### PR DESCRIPTION
Currently the user can already import a url to download a dataset, which is great.
But for a completely new user that does not know that much about these technologies, it is less user friendly to expect them to form the correct url such that the platform can import the data.
This feature addresses it in two ways, it makes templates for common sources like wikidata and dbpedia, and it displays the url that template generates, so that users can observe what kind of urls are expected.

So to implement it, I started with extending the current menu on the Datasets page under the Create Dataset button:

![different_url_imports](https://github.com/user-attachments/assets/6ffd2c9f-9d95-4122-9d11-2dea70d5428d)

By default it still selects the textbox where you can put your url, but the user can also see other templates that are available.
So the user can switch between these nested tabs, and each tab can specify fields needed to construct the url to the main form textbox.
Once the template is filled in, it will create the url according to the template, and submit the constructed url.
The templates for wikidata and dbpedia make use of their respective endpoints, and are shown here:

![different_url_imports_wikidata](https://github.com/user-attachments/assets/981f28ab-454b-47d4-b76e-c5a29486952d)
![different_url_imports_dbpedia](https://github.com/user-attachments/assets/c8c1f82c-7509-4267-9138-040bd221bc0b)

These two templates require an additional selection, it will give a popup error if you forget to fill it in and prompt you to select an option.
It can be the case that the template is filled in correctly, but the outer form fails; like when you forget to set a name for the dataset you want to import.
In that case it will show the generated url in the textbox, and allow you to resubmit with the url, it will detect that the template has already been converted to the url.
That also means you can use this feature to quickly generate the url for a common source, without the need to actually import it as a dataset.

